### PR TITLE
fix: shutdown behavior for the instance defaults to STOP

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -99,8 +99,9 @@ variable "disable_api_termination" {
 }
 
 variable "instance_initiated_shutdown_behavior" {
-  type    = string
-  default = "terminate"
+  type        = string
+  default     = "stop"
+  description = "(Optional) Shutdown behavior for the instance. Amazon defaults this to `stop` for EBS-backed instances and `terminate` for instance-store instances. Cannot be set on instance-store instances. See Shutdown Behavior for more information."
 }
 
 variable "placement_group" {


### PR DESCRIPTION
## what
`instance_initiated_shutdown_behavior`
Shutdown behavior for the instance. Amazon defaults this to `stop` for EBS-backed instances and `terminate` for instance-store instances. Cannot be set on instance-store instances. See Shutdown Behavior for more information.