### PR TITLE
feat: add support of AMI selection for Amazon Linux variants and Ubuntu based on config parameters

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,78 @@
+######################################
+# LOCALS
+######################################
+locals {
+  # Map for Amazon Linux AMI patterns
+  ami_name_map = {
+    al1    = "amzn-ami-*"
+    al2    = "amzn2-ami-hvm-*"
+    al2023 = "al2023-ami-*"
+  }
+
+  # Map for AMI owner IDs
+  ami_owner_map = {
+    al1    = "591542846629" # Amazon
+    al2    = "137112412989" # Amazon
+    al2023 = "137112412989" # Amazon
+  }
+}
+
+######################################
+# Amazon (ARM, AMD)
+######################################
+data "aws_ami" "amazon" {
+  count       = var.instance_configuration.ami.type != "ubuntu" ? 1 : 0
+  most_recent = true
+  owners      = [local.ami_owner_map[var.instance_configuration.ami.type]]
+
+  filter {
+    name   = "name"
+    values = [local.ami_name_map[var.instance_configuration.ami.type]]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [var.instance_configuration.ami.architecture]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+######################################
+# Ubuntu (ARM, AMD)
+######################################
+data "aws_ami" "ubuntu" {
+  count       = var.instance_configuration.ami.type == "ubuntu" ? 1 : 0
+  most_recent = true
+  owners      = ["099720109477"] # Canonical
+
+  filter {
+    name = "name"
+    values = [
+      "${var.instance_configuration.ami.type}/images/*${var.instance_configuration.ami.version == null ? "22.04" : var.instance_configuration.ami.version}*"
+    ]
+  }
+
+  filter {
+    name   = "architecture"
+    values = [var.instance_configuration.ami.architecture]
+  }
+
+  filter {
+    name   = "root-device-type"
+    values = ["ebs"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -15,15 +15,6 @@ locals {
   ebs_iops = var.ebs_volume_type == "io1" || var.ebs_volume_type == "io2" || var.ebs_volume_type == "gp3" ? var.ebs_iops : 0
 }
 
-data "aws_ami" "ubuntu" {
-  most_recent = "true"
-  filter {
-    name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
-  }
-  owners = ["099720109477"]
-}
-
 ##----------------------------------------------------------------------------------
 ## resource for generating or importing an SSH public key file into AWS.
 ##----------------------------------------------------------------------------------
@@ -148,7 +139,7 @@ data "aws_iam_policy_document" "kms" {
 #tfsec:ignore:aws-ec2-enforce-http-token-imds
 resource "aws_instance" "default" {
   count                                = var.enable && var.default_instance_enabled ? var.instance_count : 0
-  ami                                  = var.instance_configuration.ami == "" ? data.aws_ami.ubuntu.id : var.instance_configuration.ami
+  ami                                  = var.instance_configuration.ami.type == "ubuntu" ? data.aws_ami.ubuntu[0].id : data.aws_ami.amazon[0].id
   ebs_optimized                        = var.instance_configuration.ebs_optimized
   instance_type                        = var.instance_configuration.instance_type
   key_name                             = var.key_name == "" ? join("", aws_key_pair.default[*].key_name) : var.key_name
@@ -381,7 +372,7 @@ resource "aws_spot_instance_request" "default" {
   valid_from                     = var.spot_configuration.valid_from
 
   # Instance configuration
-  ami                                  = var.instance_configuration.ami == "" ? data.aws_ami.ubuntu.id : var.instance_configuration.ami
+  ami                                  = var.instance_configuration.ami.type == "ubuntu" ? data.aws_ami.ubuntu[0].id : data.aws_ami.amazon[0].id
   ebs_optimized                        = var.instance_configuration.ebs_optimized
   instance_type                        = var.instance_configuration.instance_type
   key_name                             = var.key_name == "" ? join("", aws_key_pair.default[*].key_name) : var.key_name

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,12 @@ variable "enable" {
 variable "instance_configuration" {
   description = "Configuration options for the EC2 instance"
   type = object({
-    ami                                  = optional(string, "")
+    ami = optional(object({
+      type         = string           # al1, al2, al2023, ubuntu
+      version      = optional(string) # Only for ubuntu
+      architecture = string           # arm64 or x86_64
+      region       = string
+    }), null)
     ebs_optimized                        = optional(bool, false)
     instance_type                        = string
     monitoring                           = optional(bool, false)


### PR DESCRIPTION
## what
- Add data source to dynamically look for AMI-IDs for Amazon Linux (AL1, AL2, AL2023) and Ubuntu based on OS type and version.
- Select latest (can be overriden by any other version) AMI by architecture automatically.

## why
- Support multiple OS type & versions for flexibility.
- Automate AMI selection to avoid manual updates.
- Ensure instances use up-to-date, correct AMIs.